### PR TITLE
24 add key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+
+data/*
+!/data/.gitkeep
+
 # C extensions
 *.so
 

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def run():
 
     if settings["run_api"]:
         dfs = pull_data()
-        export_dfs_to_azure(dfs, method="append")
+        export_dfs_to_azure(dfs, method=settings['method'])
 
     if settings["method_count"]:
         method_counts = MethodCounts()

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ def run():
 
     if settings["run_api"]:
         dfs = pull_data()
-        export_dfs_to_azure(dfs, method=settings['method'])
+        export_dfs_to_azure(dfs, method=settings["method"])
 
     if settings["method_count"]:
         method_counts = MethodCounts()

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from src.api import pull_data
 from src.log import set_logging
 from src.parse_settings import get_settings
 from src.scraper import run_scraper
-from src.db import export_dfs_to_azure
+from src.db import export_dfs_to_azure, export_dfs_to_pickles
 from src.functions import MethodCounts
 from datetime import datetime
 import logging
@@ -17,7 +17,8 @@ def run():
 
     if settings["run_api"]:
         data = pull_data()
-        export_dfs_to_azure(data.dfs, method=settings["method"])
+        #export_dfs_to_azure(data.dfs, method=settings["method"])
+        export_dfs_to_pickles(data.dfs)
 
     if settings["method_count"]:
         method_counts = MethodCounts()

--- a/main.py
+++ b/main.py
@@ -16,8 +16,8 @@ def run():
         export_dfs_to_azure(dfs, method="replace")
 
     if settings["run_api"]:
-        dfs = pull_data()
-        export_dfs_to_azure(dfs, method=settings["method"])
+        data = pull_data()
+        export_dfs_to_azure(data.dfs, method=settings["method"])
 
     if settings["method_count"]:
         method_counts = MethodCounts()

--- a/settings_template.yml
+++ b/settings_template.yml
@@ -13,3 +13,4 @@ module: pandas
 get_pandas_methods: True
 run_api: False
 method_count: True
+use_apikey: False

--- a/src/api.py
+++ b/src/api.py
@@ -2,29 +2,10 @@ import requests
 import logging
 from src.functions import MakeDataFrame
 from src.parse_settings import get_settings
+import os
 
-tag = get_settings("settings.yml")["module"]
+settings = get_settings("settings.yml")
 BASE_URL = "https://api.stackexchange.com/2.2/questions"
-
-
-def get_data():
-    """
-    Retrieve data from certain tag from stackexchange
-    :return: json with answers and questions
-    """
-
-    params = {
-        "order": "desc",
-        "sort": "creation",
-        "tagged": tag,
-        "site": "stackoverflow",
-        "filter": "!17vW0QCdaXujT5YQflD_sS_8ZjSYTT51wvIeyoJW0JSm4D",
-    }
-
-    request = requests.get(BASE_URL, params=params)
-    json = request.json()
-
-    return json
 
 
 def pull_data():
@@ -35,9 +16,60 @@ def pull_data():
     logging.info("pulling data from Stack API...")
 
     json = get_data()
+
     make_df = MakeDataFrame(json)
     dfs = make_df.create_dataframes()
     for name, df in dfs.items():
         logging.info(f"imported {name} with {len(df)} records!")
 
     return dfs
+
+
+def get_data():
+    """
+    Retrieve data from certain tag from stackexchange
+    :return: json with answers and questions
+    """
+    has_more = True
+    page = 0
+    data = list()
+
+    while has_more:
+        page += 1
+        json = request_data(page)
+        data.append(json)
+        has_more = json["has_more"]
+        logging.info(f"pulled {sum([len(x['items']) for x in data])} records...")
+
+    return data
+
+
+def request_data(page):
+
+    params = set_parameters(page)
+    request = requests.get(BASE_URL, params=params)
+    json = request.json()
+
+    return json
+
+
+def set_parameters(page):
+    params = {
+        "order": "desc",
+        "sort": "creation",
+        "tagged": settings["module"],
+        "site": "stackoverflow",
+        "filter": "!17vW0QCdaXujT5YQflD_sS_8ZjSYTT51wvIeyoJW0JSm4D",
+        "pagesize": "100",
+        "page": str(page),
+    }
+
+    if settings["use_apikey"]:
+        params.update(
+            {
+                "access_token": os.environ.get("STACKEX_ACCESS_TOKEN"),
+                "key": os.environ.get("STACKEX_KEY"),
+            }
+        )
+
+    return params

--- a/src/api.py
+++ b/src/api.py
@@ -1,6 +1,6 @@
 import requests
 import logging
-from src.functions import MakeDataFrame
+from src.functions import MakeDataFrame, ParseResponse
 from src.parse_settings import get_settings
 import os
 
@@ -11,37 +11,45 @@ BASE_URL = "https://api.stackexchange.com/2.2/questions"
 def pull_data():
     """
     Convert json retrieved from API to pandas dataframes.
-    :return: dictionary with answers and questions dataframes.
+    :return: dictionary with create_answers and questions dataframes.
     """
     logging.info("pulling data from Stack API...")
 
-    json = get_data()
+    answers, questions = get_data()
 
-    make_df = MakeDataFrame(json)
-    dfs = make_df.create_dataframes()
-    for name, df in dfs.items():
+    data = MakeDataFrame(questions, answers)
+
+    for name, df in data.dfs.items():
         logging.info(f"imported {name} with {len(df)} records!")
 
-    return dfs
+    return data
 
 
 def get_data():
     """
     Retrieve data from certain tag from stackexchange
-    :return: json with answers and questions
+    :return: json with create_answers and questions
     """
     has_more = True
     page = 0
-    data = list()
+    all_questions = list()
+    all_answers = list()
 
     while has_more:
         page += 1
         json = request_data(page)
-        data.append(json)
+        answers, questions = ParseResponse.parse_json(json)
+        all_answers = all_answers + answers
+        all_questions = all_questions + questions
         has_more = json["has_more"]
-        logging.info(f"pulled {sum([len(x['items']) for x in data])} records...")
+        logging.info(
+            f"pulled {len(all_questions)} questions and {len(all_answers)} create_answers..."
+        )
 
-    return data
+        if page == 2:
+            has_more = False
+
+    return all_answers, all_questions
 
 
 def request_data(page):

--- a/src/api.py
+++ b/src/api.py
@@ -37,11 +37,11 @@ def get_data():
 
     while has_more:
         page += 1
-        json = request_data(page)
-        answers, questions = ParseResponse.parse_json(json)
+        json_data = request_data(page)
+        answers, questions = ParseResponse.parse_json(json_data)
         all_answers = all_answers + answers
         all_questions = all_questions + questions
-        has_more = json["has_more"]
+        has_more = json_data["has_more"]
         logging.info(
             f"pulled {len(all_questions)} questions and {len(all_answers)} create_answers..."
         )
@@ -57,6 +57,8 @@ def request_data(page):
     params = set_parameters(page)
     request = requests.get(BASE_URL, params=params)
     json = request.json()
+
+    logging.info(f"quota_max={json['quota_max']} quota_remaining={json['quota_remaining']}")
 
     return json
 

--- a/src/db.py
+++ b/src/db.py
@@ -130,7 +130,7 @@ def execute_sql_file(sql_file):
 def export_data(df, name, method):
     """
     Write data to database
-    :param df: data set with NEW records (either questions or answers).
+    :param df: data set with NEW records (either questions or create_answers).
     :param name: name of table.
     :param method: append or replace data in database.
     :return: None

--- a/src/db.py
+++ b/src/db.py
@@ -68,7 +68,7 @@ def get_overlapping_records(df, name):
     :return:  a list of records that are overlapping
     """
 
-    current_db = read_from_database(name, db_engine=auth_azure(), schema="method_usage")
+    current_db = read_from_database(name, db_engine=auth_azure(), schema=SCHEMA)
     overlapping_records = current_db[current_db[f"{name}_id"].isin(df[f"{name}_id"])]
     del_list = overlapping_records.astype(str)[f"{name}_id"].to_list()
 
@@ -82,7 +82,7 @@ def create_sql_delete_stmt(del_list, name):
     :return: SQL statement for deleting the specific records
     """
     sql_list = ", ".join(del_list)
-    sql_stmt = f"DELETE FROM method_usage.pandas_{name} WHERE {name}_id IN ({sql_list})"
+    sql_stmt = f"DELETE FROM {SCHEMA}.pandas_{name} WHERE {name}_id IN ({sql_list})"
     logging.info(f"{len(del_list)} {name} in delete statement")
 
     return sql_stmt

--- a/src/functions.py
+++ b/src/functions.py
@@ -84,7 +84,6 @@ class MakeDataFrame:
         df["body"] = df.body.str.replace("<[^<]+?>", "")
 
         return df
-        return df
 
     def create_dataframes(self):
         """

--- a/src/functions.py
+++ b/src/functions.py
@@ -11,23 +11,31 @@ SCHEMA = settings["schema"]
 MODULE = settings["module"]
 
 
-class MakeDataFrame:
+class ParseResponse:
     def __init__(self, json):
         self.json = json
 
-    def split_json(self):
+    def parse_json(self):
         """
         Split json into questions part and answer part.
         The answer part is a nested JSON itself.
         :return: two lists of dictionaries
         """
-        items = self.json["items"]
+        items = self["items"]
         # we use pop, because we want to
-        # remove answers from the original dictionary
+        # remove create_answers from the original dictionary
         answers = [item.pop("answers", None) for item in items]
         questions = items
 
         return answers, questions
+
+
+class MakeDataFrame:
+    def __init__(self, questions, answers):
+
+        self.answers = answers
+        self.questions = questions
+        self.dfs = self.create_dataframes()
 
     @staticmethod
     def select_string_columns(df):
@@ -47,49 +55,45 @@ class MakeDataFrame:
 
         return df
 
-    def answers(self, answers):
+    def create_answers(self):
         """
-        Create answers dataframe from list of dictionaries
+        Create create_answers dataframe from list of dictionaries
         :param answers: list of dictionaries
         :return: DataFrame
         """
 
-        answers = pd.concat([pd.DataFrame(x) for x in answers], ignore_index=True)
-        answers = self.get_user_id(answers, "owner")
+        df = pd.concat([pd.DataFrame(x) for x in self.answers], ignore_index=True)
+        df = self.get_user_id(df, "owner")
         date_cols = ["last_activity_date", "creation_date", "last_edit_date"]
-        answers[date_cols] = answers[date_cols].apply(
-            lambda x: pd.to_datetime(x, unit="s", utc=True)
-        )
-        answers["body"] = answers.body.str.replace("<[^<]+?>", "")
+        df[date_cols] = df[date_cols].apply(lambda x: pd.to_datetime(x, unit="s", utc=True))
+        df["body"] = df.body.str.replace("<[^<]+?>", "")
 
-        return answers
+        return df
 
-    def questions(self, questions):
+    def create_questions(self):
         """
         Create questions dataframe from list of dictionaries
         :param questions: list of dictionaries
         :return: DataFrame
         """
-        questions = pd.DataFrame(questions)
-        questions = self.get_user_id(questions, "owner")
-        questions["tags"] = questions["tags"].str.join(", ")
+        df = pd.DataFrame(self.questions)
+        df = self.get_user_id(df, "owner")
+        df["tags"] = df["tags"].str.join(", ")
         date_cols = ["last_activity_date", "creation_date", "last_edit_date"]
-        questions[date_cols] = questions[date_cols].apply(
-            lambda x: pd.to_datetime(x, unit="s", utc=True)
-        )
-        questions["body"] = questions.body.str.replace("<[^<]+?>", "")
+        df[date_cols] = df[date_cols].apply(lambda x: pd.to_datetime(x, unit="s", utc=True))
+        df["body"] = df.body.str.replace("<[^<]+?>", "")
 
-        return questions
+        return df
+        return df
 
     def create_dataframes(self):
         """
-        Create both answers, questions dataframes
-        :return: answers dataframe, questions dataframe
+        Create both create_answers, questions dataframes
+        :return: create_answers dataframe, questions dataframe
         """
-        answers, questions = self.split_json()
         dfs = {
-            "answer": self.answers(answers),
-            "question": self.questions(questions),
+            "answer": self.create_answers(),
+            "question": self.create_questions(),
         }
 
         return dfs

--- a/src/models/answer.sql
+++ b/src/models/answer.sql
@@ -1,5 +1,5 @@
-DROP TABLE IF EXISTS method_usage.pandas_answer;
-CREATE TABLE method_usage.pandas_answer (
+DROP TABLE IF EXISTS test.pandas_answer;
+CREATE TABLE test.pandas_answer (
 	answer_id int not null primary key,
 	question_id int not null,
 	owner int not null,

--- a/src/models/method_counts_answer.sql
+++ b/src/models/method_counts_answer.sql
@@ -1,5 +1,5 @@
-DROP TABLE IF EXISTS method_usage.method_counts_answer;
-CREATE TABLE method_usage.method_counts_answer (
+DROP TABLE IF EXISTS test.method_counts_answer;
+CREATE TABLE test.method_counts_answer (
     methods varchar(255) not null,
     count int not null,
 	module varchar(255) not null,

--- a/src/models/method_counts_question.sql
+++ b/src/models/method_counts_question.sql
@@ -1,5 +1,5 @@
-DROP TABLE IF EXISTS method_usage.method_counts_question;
-CREATE TABLE method_usage.method_counts_question (
+DROP TABLE IF EXISTS test.method_counts_question;
+CREATE TABLE test.method_counts_question (
     methods varchar(255) not null,
     count int not null,
 	module varchar(255) not null,

--- a/src/models/question.sql
+++ b/src/models/question.sql
@@ -1,5 +1,5 @@
-DROP TABLE IF EXISTS method_usage.pandas_question;
-CREATE TABLE method_usage.pandas_question (
+DROP TABLE IF EXISTS test.pandas_question;
+CREATE TABLE test.pandas_question (
 	question_id INT NOT NULL PRIMARY KEY,
 	tags VARCHAR(255),
 	owner INT NOT NULL,


### PR DESCRIPTION
explanation:
Previously only the first 30 records of the request where being used in the request. The Stack exchange response (with use of the custom filter)  has around 170.000 records. With this version, it is possible to pull all the records. The changes that made this possible:

- changed request parameter `pagesize:30` to `pagesize:100`
- added pagination to the get_data function.
- added functionality for adding your Stack Exchange API key. also added the run variable `use_apikey` to the settings.yml.
- added funtionality for storing the results in pickle files. In case the data upload fails, the results will be available in the pickles.
- added folder `data` for storing the pickle files. `data` is added to the `.gitignore`.
